### PR TITLE
Fix docs link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The BitcoinToken library is a collection of tools that make it easy to integrate
  * **BitcoinDb** store data on the blockchain
  * **BitcoinToken** issue tokens
 
-The docs are at [www.bitcointoken.com/docs](www.bitcointoken.com/docs)
+The docs are at [www.bitcointoken.com/docs](https://www.bitcointoken.com/docs)
 
 
 ## Install


### PR DESCRIPTION
The docs link is broken in github.  Being read as a relative path.  Including the protocol will force it.